### PR TITLE
pin minitest due to bug in rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,9 @@ group :test do
   gem 'minitest-reporters',       '1.1.9'
   gem 'guard',                    '2.13.0'
   gem 'guard-minitest',           '2.4.4'
+  # See this bug: https://github.com/seattlerb/minitest/issues/689
+  # Another option is to upgrade rails, but this seemed quicker and easier for now
+  gem 'minitest', '5.10.1'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,7 +242,7 @@ GEM
     mimemagic (0.3.2)
     mini_magick (4.5.1)
     mini_portile2 (2.1.0)
-    minitest (5.10.2)
+    minitest (5.10.1)
     minitest-reporters (1.1.9)
       ansi
       builder
@@ -362,6 +362,7 @@ DEPENDENCIES
   jquery-rails (= 4.1.1)
   listen (= 3.0.8)
   mini_magick (= 4.5.1)
+  minitest (= 5.10.1)
   minitest-reporters (= 1.1.9)
   pg (= 0.18.4)
   puma (= 3.4.0)

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -15,11 +15,7 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
     assert flash.empty?
   end
   
-<<<<<<< HEAD
   test "login with valid information followed by logout" do
-=======
-    test "login with valid information followed by logout" do
->>>>>>> upstream/master
     get login_path
     post login_path, params: { session: { email:    @user.email,
                                           password: 'password' } }
@@ -42,11 +38,7 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
   end
   
   test "authenticated? should return false for a user with nil digest" do
-<<<<<<< HEAD
     assert_not @user.authenticated?(:remember, '')
-=======
-    assert_not @user.authenticated?(:remember,'')
->>>>>>> upstream/master
   end
   
   test "login with remembering" do

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -15,19 +15,6 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
     assert flash.empty?
   end
   
-  test "valid signup information" do
-    get signup_path
-    assert_difference 'User.count', 1 do
-      post users_path, params: { user: { name:  "Example User",
-                                         email: "user@example.com",
-                                         password:              "password",
-                                         password_confirmation: "password" } }
-    end
-    follow_redirect!
-    assert_template 'users/show'
-    assert is_logged_in?
-  end
-  
   test "login with valid information followed by logout" do
     get login_path
     post login_path, params: { session: { email:    @user.email,

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -15,7 +15,7 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
     assert flash.empty?
   end
   
-    test "valid signup information" do
+  test "valid signup information" do
     get signup_path
     assert_difference 'User.count', 1 do
       post users_path, params: { user: { name:  "Example User",
@@ -27,7 +27,8 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
     assert_template 'users/show'
     assert is_logged_in?
   end
-    test "login with valid information followed by logout" do
+  
+  test "login with valid information followed by logout" do
     get login_path
     post login_path, params: { session: { email:    @user.email,
                                           password: 'password' } }
@@ -48,10 +49,12 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?]", logout_path,      count: 0
     assert_select "a[href=?]", user_path(@user), count: 0
   end
+  
   test "authenticated? should return false for a user with nil digest" do
-    assert_not @user.authenticated?('')
+    assert_not @user.authenticated?(:remember, '')
   end
-    test "login with remembering" do
+  
+  test "login with remembering" do
     log_in_as(@user, remember_me: '1')
     assert_not_empty cookies['remember_token']
   end


### PR DESCRIPTION
Howdy Jake,

Looks like there is a bug in rails that was recently fixed. See https://github.com/seattlerb/minitest/issues/689.  For the quick fix add this to the test group in your gem file:
`gem 'minitest', '5.10.1'`

Then run:
`bundle update minitest`

Another option if you're feeling adventurous is to update rails. Since the tutorial has your rails version pinned at 5.0.1, I'd probably go with the quick fix until you've completed the tutorial.

Good luck,

JB